### PR TITLE
Strings can now hexdigest md5/sha1/sha256,384,512

### DIFF
--- a/spec/opto/types/string_spec.rb
+++ b/spec/opto/types/string_spec.rb
@@ -36,6 +36,30 @@ describe Opto::Types::String do
     it 'chomps' do
       expect(subject.new(chomp: true).sanitize_chomp(" Foo  \n")).to eq " Foo  "
     end
+
+    it 'hexdigests md5' do
+      expect(subject.new(hexdigest: 'md5').sanitize_hexdigest("foo")).to eq "acbd18db4cc2f85cedef654fccc4a4d8"
+    end
+
+    it 'hexdigests sha1' do
+      expect(subject.new(hexdigest: 'sha1').sanitize_hexdigest("foo")).to eq "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"
+    end
+
+    it 'hexdigests sha2-256' do
+      expect(subject.new(hexdigest: 'sha256').sanitize_hexdigest("foo")).to eq "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+    end
+
+    it 'hexdigests sha2-384' do
+      expect(subject.new(hexdigest: 'sha384').sanitize_hexdigest("foo")).to eq "98c11ffdfdd540676b1a137cb1a22b2a70350c9a44171d6b1180c6be5cbb2ee3f79d532c8a1dd9ef2e8e08e752a3babb"
+    end
+
+    it 'hexdigests sha2-512' do
+      expect(subject.new(hexdigest: 'sha512').sanitize_hexdigest("foo")).to eq "f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7"
+    end
+
+    it 'hexdigest raises with unknown digester' do
+      expect{subject.new(hexdigest: 'foo').sanitize_hexdigest("foo")}.to raise_error(TypeError)
+    end
   end
 
   context 'validate' do


### PR DESCRIPTION
For example Graylog requires a sha2 hash of the root password in env, not the actual password.
