### PR TITLE
Arrays initially contained a nil instead of being empty

### DIFF
--- a/lib/opto/types/array.rb
+++ b/lib/opto/types/array.rb
@@ -35,6 +35,8 @@ module Opto
           value
         elsif value.kind_of?(::String)
           value.split(options[:split])
+        elsif value.nil?
+          []
         else
           [value]
         end

--- a/spec/opto/types/array_spec.rb
+++ b/spec/opto/types/array_spec.rb
@@ -47,5 +47,10 @@ describe Opto::Types::Array do
     it 'can count' do
       expect(subject.new(count: true).sanitize_output(["abc", "cde", "bcd"])).to eq 3
     end
+
+    it 'should have an empty array initially' do
+      arr = Opto::Option.new(type: :array, name: 'array')
+      expect(arr.value).to be_empty
+    end
   end
 end


### PR DESCRIPTION
before:

```ruby
Opto::Option.new(type: :array, name: foo).value
=> [nil]
```

after:

```ruby
Opto::Option.new(type: :array, name: foo).value
=> []
```
