### PR TITLE
Support complex conditionals, add condition resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The option type handlers can perform validations, such as defining a range or le
 
 Transformations can be performed on values, such as upcasing strings or removing white space.
 
-Options can have simple conditionals for determining if it needs to be processed or not, an option for defining a database
+Options can have simple conditionals for determining if it needs to be processed or not, for example: an option for defining a database
 password can be processed only if a database has been selected.
 
 Finally the value for the option can be placed to some destination, such as an environment variable or sent to a command.
@@ -138,7 +138,7 @@ Ok, so what to do with the values? There's setters for that.
 
 ## Conditionals
 
-There's also rudimentary conditional support:
+There's also support for conditionals
 
 ```yaml
   - name: foo
@@ -194,7 +194,93 @@ There's also rudimentary conditional support:
       - baz   # AND baz is not null
 ```
 
-Pretty nifty, right?
+### Complex conditionals
+
+You can define more complicated conditionals by supplying a hash instead of a value:
+
+```yaml
+# value. same as foo == 5
+only_if:
+  foo: 5
+```
+
+```yaml
+# hash. same as foo > 5 && foo <= 10
+only_if:
+  foo:
+    gt: 5
+    lte: 10
+```
+
+### Complex conditional operators
+
+#### `lt`, `lte`
+
+less than / less than or equal to
+
+#### `gt`, `gte`
+
+greater than / greater than or equal to
+
+#### `eq`, `ne`
+
+equals / not equals
+
+#### `start_with`, `end_with`
+
+"foobar" starts with "foo" and ends with "bar".
+
+#### `contain`
+
+Can be used for strings and arrays:
+
+```yaml
+arr:
+  type: array
+  value:
+    - a
+    - b
+    - c
+
+str:
+  type: string
+  value: foobar
+
+x:
+  type: boolean
+  from:
+    condition:
+      - if:
+        arr:
+          contain: b
+        str:
+          contain: b
+        then: true
+      - else: false
+      -
+# group.value_of('x')
+# => true
+```
+
+#### `any_of`
+
+true when the value is one of the supplied values. Input is either a comma separated string or an array.
+
+```yaml
+foo:
+  skip_if:
+    bar:
+      any_of: foo,baz
+```
+
+```yaml
+foo:
+  skip_if:
+    bar:
+      any_of:
+        - foo
+        - baz
+```
 
 ## Examples
 
@@ -444,6 +530,47 @@ greeting:
 
 # group.value_of('greeting') => "Hello, world!"
 ```
+
+### condition
+
+Hint is an array containing if/then/elsif/else definitions. Sets the value based on the values of other variables.
+
+Example:
+```yaml
+int:
+  type: integer
+  value: 5
+
+str:
+  type: string
+  from:
+    condition:
+      - if:
+          int: 5
+        then: "five"
+      - elsif:
+          int: 6
+        then: "six"
+      - else: "not five or six"
+```
+
+```ruby
+group.option('int').set(4)
+group.option('str').resolve
+=> "not five or six"
+group.option('int').set(5)
+group.option('str').resolve
+=> "five"
+group.option('int').set(6)
+group.option('str').resolve
+=> "six"
+```
+
+When an "else" is not defined and none of the conditions match, a null value will be returned.
+
+The syntax for conditionals and complex conditionals is documented above in the chapter about conditionals.
+```
+
 
 ## Default setters
 

--- a/README.md
+++ b/README.md
@@ -569,8 +569,6 @@ group.option('str').resolve
 When an "else" is not defined and none of the conditions match, a null value will be returned.
 
 The syntax for conditionals and complex conditionals is documented above in the chapter about conditionals.
-```
-
 
 ## Default setters
 

--- a/lib/opto/extensions/hash_string_or_symbol_key.rb
+++ b/lib/opto/extensions/hash_string_or_symbol_key.rb
@@ -8,6 +8,14 @@ module Opto
           super(key.to_s) || super(key.to_sym)
         end
 
+        def has_key?(key)
+          if key.nil?
+            super(nil)
+          else
+            super(key.to_s) || super(key.to_sym)
+          end
+        end
+
         def delete(key)
           return nil if key.nil?
           super(key) || super(key.to_s) || super(key.to_sym)

--- a/lib/opto/resolvers/condition.rb
+++ b/lib/opto/resolvers/condition.rb
@@ -1,0 +1,90 @@
+require 'opto/extensions/snake_case'
+require 'opto/extensions/hash_string_or_symbol_key'
+
+if RUBY_VERSION < '2.1'
+  using Opto::Extension::SnakeCase
+  using Opto::Extension::HashStringOrSymbolKey
+end
+
+module Opto
+  module Resolvers
+    # Allows setting the value conditionally based on other variables
+    #
+    # Example:
+    # from:
+    #   condition:
+    #     - if:
+    #         db_instances: 1
+    #       then: single
+    #     - elsif:
+    #         db_instances:
+    #           gt: 1
+    #       then: multi
+    #     - else: none
+    #
+    # Which is the same as:
+    # if $db_instances == 1
+    #   return "single"
+    # elsif $db_instances > 1
+    #   return "multi"
+    # else
+    #   return "none"
+    # end
+    #
+    # If you don't define an else, a null will be returned when no conditions match.
+    class Condition < Opto::Resolver
+
+      using Opto::Extension::HashStringOrSymbolKey unless RUBY_VERSION < '2.1'
+
+      class HashCond
+        attr_reader :condition
+        attr_reader :result
+        attr_reader :group
+
+        def initialize(group, options={})
+          @group = group
+          if options.has_key?(:else)
+            @result = options[:else]
+            @else = true
+          elsif options.has_key?(:if) || options.has_key?(:elsif)
+            @condition = options[:if] || options[:elsif]
+            if options.has_key?(:then)
+              @result = options[:then]
+            else
+              raise ArgumentError, "Invalid condition definition: #{options.inspect} (no 'then')"
+            end
+            @else = false
+          else
+            raise ArgumentError, "Invalid condition definition: #{options.inspect} (no 'if', 'elsif' or 'else')"
+          end
+        end
+
+        def else?
+          @else
+        end
+
+        def true?
+          return true if else?
+          return true if group.all_true?(condition)
+          false
+        end
+      end
+
+      def resolve
+        raise TypeError, "An Array of Hashes expected" unless hint.kind_of?(Array)
+        raise TypeError, "An Array of Hashes expected" unless hint.all? {|h| h.kind_of?(Hash) }
+        raise TypeError, "Can't use condition resolver when option isn't a member of an option group" if option.group.nil?
+
+        conditions = hint.map {|h| HashCond.new(option.group, h) }
+
+        unless conditions.last.else?
+          conditions << HashCond.new(:else => nil)
+        end
+
+        matching_condition = conditions.find {|c| c.true? }
+        matching_condition.result
+      end
+    end
+  end
+end
+

--- a/spec/opto/resolvers/condition_spec.rb
+++ b/spec/opto/resolvers/condition_spec.rb
@@ -1,0 +1,89 @@
+require_relative '../../spec_helper'
+
+describe Opto::Resolvers::Condition do
+
+  describe '#resolve' do
+    let(:subject) { described_class }
+
+    let(:group) { Opto::Group.new }
+
+    before(:each) do
+      group.build_option(type: 'string', name: 'str', value: 'foo')
+      group.build_option(type: 'boolean', name: 'bool', value: true)
+      group.build_option(type: 'integer', name: 'int', value: 4)
+    end
+
+    it 'does if/elsif/else' do
+      opt = group.build_option(
+        type: 'string',
+        name: 'opt',
+        from: {
+          condition: [
+            { if: { str: "foo" },
+              then: "foofoo"
+            },
+            { elsif: { str: "bar" },
+              then: "barbar"
+            },
+            { else: "foobar" }
+          ]
+        }
+      )
+
+      group.option('str').set('foo')
+      expect(opt.resolve).to eq 'foofoo'
+      group.option('str').set('bar')
+      expect(opt.resolve).to eq 'barbar'
+      group.option('str').set('baz')
+      expect(opt.resolve).to eq 'foobar'
+    end
+
+    it 'does if/elsif/else with complex conditions' do
+      opt = group.build_option(
+        type: 'string',
+        name: 'opt',
+        from: {
+          condition: [
+            { if: { str: { start_with: "foo", end_with: "doo", any_of: "foo,foovoodoo", ne: "foodoodoo", contain: "oo", eq: 'foovoodoo' }, int: { gt: 5, lt: 10, lte: 9, gte: 6, any_of: [6,7,8,9] } },
+              then: "foofoo"
+            },
+            { else: "foobar" }
+          ]
+        }
+      )
+
+      group.option('str').set('foo')
+      expect(opt.resolve).to eq 'foobar'
+      group.option('int').set(5)
+      expect(opt.resolve).to eq 'foobar'
+      group.option('int').set(10)
+      expect(opt.resolve).to eq 'foobar'
+      group.option('int').set(9)
+      expect(opt.resolve).to eq 'foobar'
+      group.option('str').set("foovoodoo")
+      group.option('int').set(5)
+      expect(opt.resolve).to eq 'foobar'
+      group.option('int').set(10)
+      expect(opt.resolve).to eq 'foobar'
+      group.option('int').set(9)
+      expect(opt.resolve).to eq 'foofoo'
+      group.option('str').set("foodoodoo")
+      expect(opt.resolve).to eq 'foobar'
+    end
+
+    it 'raises if hint is not an array' do
+      expect{subject.new(foo: :bar).resolve}.to raise_error(TypeError)
+      expect{subject.new(:foo).resolve}.to raise_error(TypeError)
+      expect{subject.new(1).resolve}.to raise_error(TypeError)
+    end
+
+    it 'raises if hint is not an array of hashes' do
+      expect{subject.new([:foo, :bar]).resolve}.to raise_error(TypeError)
+      expect{subject.new([:foo, {foo: :bar}]).resolve}.to raise_error(TypeError)
+    end
+
+  end
+end
+
+
+


### PR DESCRIPTION
Before you could only define simple conditionals such as:

```yaml
skip_if: foo
# skip when foo is truthy
skip_if:
  foo: hello
# skip when value of foo is "hello"
```

Now you can go nuts with it:

```yaml
skip_if:
  foobar:
    start_with: foo
    end_with: bar
    contain: "oob"
  int:
    lt: 5
    gte: 3
```

The condition resolver can use conditionals to set a value for an option:

```yaml
foo:
  type: string
  from:
    condition:
      - if:
           bar: "baz"
        then: "hello"
      - elsif:
           bar: "buz"
        then: "yello"
      - else: "cello"
``` 