### PR TITLE
Drop support for Ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: ruby
 rvm:
-  - 2.0.0-p648
   - 2.1.8
   - 2.2.3
-  - 2.3.1
   - 2.3.3
   - 2.4.0
   - jruby-9.1.5.0
@@ -18,4 +16,4 @@ deploy:
   gem: opto
   on:
     tags: true
-    rvm: 2.3.1
+    rvm: 2.4.0

--- a/lib/opto.rb
+++ b/lib/opto.rb
@@ -2,11 +2,6 @@ require "opto/version"
 require 'opto/extensions/snake_case'
 require 'opto/extensions/hash_string_or_symbol_key'
 
-if RUBY_VERSION < '2.1'
-  using Opto::Extension::SnakeCase
-  using Opto::Extension::HashStringOrSymbolKey
-end
-
 require "opto/option"
 require "opto/group"
 
@@ -15,6 +10,9 @@ require 'yaml'
 # An option parser/validator/resolver
 #
 module Opto
+  using Opto::Extension::SnakeCase
+  using Opto::Extension::HashStringOrSymbolKey
+
   # Initialize a new Opto::Option (when input is hash) or an Opto::Group (when input is an array of hashes)
   def self.new(opts)
     case opts

--- a/lib/opto/extensions/symbolize_keys.rb
+++ b/lib/opto/extensions/symbolize_keys.rb
@@ -1,0 +1,15 @@
+module Opto
+  module Extension
+    # Refines String to have .snakecase method that turns
+    # StringLikeThis into a string_like_this
+    module SymbolizeKeys
+      refine Hash do
+        def symbolize_keys
+          each_with_object(dup.clear) do |(key, value), hash|
+            hash[(key.to_sym rescue key)] = value
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/opto/group.rb
+++ b/lib/opto/group.rb
@@ -2,11 +2,6 @@ require 'opto/option'
 require 'opto/extensions/snake_case'
 require 'opto/extensions/hash_string_or_symbol_key'
 
-if RUBY_VERSION < '2.1'
-  using Opto::Extension::SnakeCase
-  using Opto::Extension::HashStringOrSymbolKey
-end
-
 module Opto
   # A group of Opto::Option instances. Members of Groups can see their relatives
   # and their values. Such as `option.value_of('another_option')`
@@ -14,7 +9,7 @@ module Opto
   # Most Array instance methods are delegated, such as .map, .each, .find etc.
   class Group
 
-    using Opto::Extension::HashStringOrSymbolKey unless RUBY_VERSION < '2.1'
+    using Opto::Extension::HashStringOrSymbolKey
 
     attr_reader :options, :defaults
 

--- a/lib/opto/option.rb
+++ b/lib/opto/option.rb
@@ -4,21 +4,14 @@ require_relative 'setter'
 require_relative 'extensions/snake_case'
 require_relative 'extensions/hash_string_or_symbol_key'
 
-if RUBY_VERSION < '2.1'
-  using Opto::Extension::SnakeCase
-  using Opto::Extension::HashStringOrSymbolKey
-end
-
 module Opto
   # What is an option? It's like a variable that has a value, which can be validated or
   # manipulated on creation. The value can be resolved from a number of origins, such as
   # an environment variable or random string generator.
   class Option
 
-    unless RUBY_VERSION < '2.1'
-      using Opto::Extension::SnakeCase
-      using Opto::Extension::HashStringOrSymbolKey
-    end
+    using Opto::Extension::SnakeCase
+    using Opto::Extension::HashStringOrSymbolKey
 
     attr_accessor :type
     attr_accessor :name

--- a/lib/opto/resolver.rb
+++ b/lib/opto/resolver.rb
@@ -1,11 +1,6 @@
 require 'opto/extensions/snake_case'
 require 'opto/extensions/hash_string_or_symbol_key'
 
-if RUBY_VERSION < '2.1'
-  using Opto::Extension::SnakeCase
-  using Opto::Extension::HashStringOrSymbolKey
-end
-
 module Opto
   # Base for resolvers.
   #
@@ -15,7 +10,7 @@ module Opto
   # RandomString, which can generate random strings of defined length.
   class Resolver
 
-    using Opto::Extension::SnakeCase unless RUBY_VERSION < '2.1'
+    using Opto::Extension::SnakeCase
 
     attr_accessor :hint
     attr_accessor :option

--- a/lib/opto/resolvers/condition.rb
+++ b/lib/opto/resolvers/condition.rb
@@ -1,11 +1,6 @@
 require 'opto/extensions/snake_case'
 require 'opto/extensions/hash_string_or_symbol_key'
 
-if RUBY_VERSION < '2.1'
-  using Opto::Extension::SnakeCase
-  using Opto::Extension::HashStringOrSymbolKey
-end
-
 module Opto
   module Resolvers
     # Allows setting the value conditionally based on other variables
@@ -34,7 +29,7 @@ module Opto
     # If you don't define an else, a null will be returned when no conditions match.
     class Condition < Opto::Resolver
 
-      using Opto::Extension::HashStringOrSymbolKey unless RUBY_VERSION < '2.1'
+      using Opto::Extension::HashStringOrSymbolKey
 
       class HashCond
         attr_reader :condition

--- a/lib/opto/resolvers/evaluate.rb
+++ b/lib/opto/resolvers/evaluate.rb
@@ -1,17 +1,12 @@
 require 'opto/extensions/snake_case'
 require 'opto/extensions/hash_string_or_symbol_key'
 
-if RUBY_VERSION < '2.1'
-  using Opto::Extension::SnakeCase
-  using Opto::Extension::HashStringOrSymbolKey
-end
-
 module Opto
   module Resolvers
     # Geneerate a new random number. Requires :min and :max in hint to define range.
     class Evaluate < Opto::Resolver
 
-      using Opto::Extension::HashStringOrSymbolKey unless RUBY_VERSION < '2.1'
+      using Opto::Extension::HashStringOrSymbolKey
 
       def resolve
         raise TypeError, "String required" unless hint.kind_of?(String)

--- a/lib/opto/resolvers/interpolate.rb
+++ b/lib/opto/resolvers/interpolate.rb
@@ -1,11 +1,6 @@
 require 'opto/extensions/snake_case'
 require 'opto/extensions/hash_string_or_symbol_key'
 
-if RUBY_VERSION < '2.1'
-  using Opto::Extension::SnakeCase
-  using Opto::Extension::HashStringOrSymbolKey
-end
-
 module Opto
   module Resolvers
     # Interpolates values from other options into a template string.
@@ -15,7 +10,7 @@ module Opto
     #   interpolate: mysql://admin:$mysql_admin_pass@mysql:1234/$mysql_db_name
     class Interpolate < Opto::Resolver
 
-      using Opto::Extension::HashStringOrSymbolKey unless RUBY_VERSION < '2.1'
+      using Opto::Extension::HashStringOrSymbolKey
 
       def resolve
         raise TypeError, "String expected" unless hint.kind_of?(String)

--- a/lib/opto/resolvers/random_number.rb
+++ b/lib/opto/resolvers/random_number.rb
@@ -1,17 +1,12 @@
 require 'opto/extensions/snake_case'
 require 'opto/extensions/hash_string_or_symbol_key'
 
-if RUBY_VERSION < '2.1'
-  using Opto::Extension::SnakeCase
-  using Opto::Extension::HashStringOrSymbolKey
-end
-
 module Opto
   module Resolvers
     # Geneerate a new random number. Requires :min and :max in hint to define range.
     class RandomNumber < Opto::Resolver
 
-      using Opto::Extension::HashStringOrSymbolKey unless RUBY_VERSION < '2.1'
+      using Opto::Extension::HashStringOrSymbolKey
 
       def resolve
         raise ArgumentError, "Range not set" if hint.nil?

--- a/lib/opto/resolvers/random_string.rb
+++ b/lib/opto/resolvers/random_string.rb
@@ -1,31 +1,26 @@
 require 'opto/extensions/snake_case'
 require 'opto/extensions/hash_string_or_symbol_key'
 
-if RUBY_VERSION < '2.1'
-  using Opto::Extension::SnakeCase
-  using Opto::Extension::HashStringOrSymbolKey
-end
-
 module Opto
   module Resolvers
     # Generates a random string.
     #
-    # Requires at least  :length. 
-    # Also accepts :charset which can be one of: 
-    # - numbers (0-9), 
-    # - letters (a-z + A-Z), 
-    # - downcase (a-z), 
+    # Requires at least  :length.
+    # Also accepts :charset which can be one of:
+    # - numbers (0-9),
+    # - letters (a-z + A-Z),
+    # - downcase (a-z),
     # - upcase (A-Z),
-    # - alphanumeric (0-9 + a-z + A-Z), 
-    # - hex (0-9 + a-f), 
-    # - hex_upcase (0-9 + A-F), 
+    # - alphanumeric (0-9 + a-z + A-Z),
+    # - hex (0-9 + a-f),
+    # - hex_upcase (0-9 + A-F),
     # - base64 (base64 charset (length has to be divisible by four when using base64)),
     #-  ascii_printable (all printable ascii chars)
     # - or a set of characters, for example:
     #   { length: 8, charset: '01' }  Will generate something like:  01001100
     class RandomString < Opto::Resolver
 
-      using Opto::Extension::HashStringOrSymbolKey unless RUBY_VERSION < '2.1'
+      using Opto::Extension::HashStringOrSymbolKey
 
       def charset(name)
         case name.to_s
@@ -56,7 +51,7 @@ module Opto
       end
 
       def resolve
-        if hint.kind_of?(Hash) 
+        if hint.kind_of?(Hash)
           if hint[:length].nil?
             raise ArgumentError, "Invalid settings for random string. Required: length, optional: charset. Charsets : numbers, letters, alphanumeric, hex, base64, ascii_printable and X-Y range."
           end

--- a/lib/opto/setter.rb
+++ b/lib/opto/setter.rb
@@ -1,11 +1,6 @@
 require 'opto/extensions/snake_case'
 require 'opto/extensions/hash_string_or_symbol_key'
 
-if RUBY_VERSION < '2.1'
-  using Opto::Extension::SnakeCase
-  using Opto::Extension::HashStringOrSymbolKey
-end
-
 module Opto
   # Base for Setters.
   #
@@ -15,7 +10,7 @@ module Opto
   # RandomString, which can generate random strings of defined length.
   class Setter
 
-    using Opto::Extension::SnakeCase unless RUBY_VERSION < '2.1'
+    using Opto::Extension::SnakeCase
 
     attr_accessor :hint
     attr_accessor :option

--- a/lib/opto/setters/environment_variable.rb
+++ b/lib/opto/setters/environment_variable.rb
@@ -1,11 +1,6 @@
 require 'opto/extensions/snake_case'
 require 'opto/extensions/hash_string_or_symbol_key'
 
-if RUBY_VERSION < '2.1'
-  using Opto::Extension::SnakeCase
-  using Opto::Extension::HashStringOrSymbolKey
-end
-
 module Opto
   module Setters
     # Set a value to environment.
@@ -15,7 +10,7 @@ module Opto
     # Everything will be converted to strings unless hint is a hash with :options. (also include :name in that case)
     class Env < Opto::Setter
 
-      using Opto::Extension::HashStringOrSymbolKey unless RUBY_VERSION < '2.1'
+      using Opto::Extension::HashStringOrSymbolKey
 
       attr_accessor :env_name, :dont_stringify
 

--- a/lib/opto/types/array.rb
+++ b/lib/opto/types/array.rb
@@ -1,8 +1,4 @@
 require_relative '../type'
-if RUBY_VERSION < '2.1'
-  using Opto::Extension::SnakeCase
-  using Opto::Extension::HashStringOrSymbolKey
-end
 
 module Opto
   module Types
@@ -17,7 +13,7 @@ module Opto
     #   - compact: when true, removes nils and blanks
     #   - count: when true, the output is the count of items in the array
     class Array < Opto::Type
-      using Opto::Extension::HashStringOrSymbolKey unless RUBY_VERSION < '2.1'
+      using Opto::Extension::HashStringOrSymbolKey
 
 
       OPTIONS = {

--- a/lib/opto/types/boolean.rb
+++ b/lib/opto/types/boolean.rb
@@ -2,11 +2,6 @@ require_relative '../type'
 require 'opto/extensions/snake_case'
 require 'opto/extensions/hash_string_or_symbol_key'
 
-if RUBY_VERSION < '2.1'
-  using Opto::Extension::SnakeCase
-  using Opto::Extension::HashStringOrSymbolKey
-end
-
 module Opto
   module Types
     # A boolean value.
@@ -19,7 +14,7 @@ module Opto
     #   :true says "true" by default when outputting a string
     #   :false says "false" by default when outputting a string
     class Boolean < Opto::Type
-      using Opto::Extension::HashStringOrSymbolKey unless RUBY_VERSION < '2.1'
+      using Opto::Extension::HashStringOrSymbolKey
 
       OPTIONS = {
         truthy: ['true', 'yes', '1', 'on', 'enabled', 'enable'],

--- a/lib/opto/types/enum.rb
+++ b/lib/opto/types/enum.rb
@@ -2,11 +2,6 @@ require_relative '../type'
 require 'opto/extensions/snake_case'
 require 'opto/extensions/hash_string_or_symbol_key'
 
-if RUBY_VERSION < '2.1'
-  using Opto::Extension::SnakeCase
-  using Opto::Extension::HashStringOrSymbolKey
-end
-
 module Opto
   module Types
     # A list of possible values
@@ -39,7 +34,7 @@ module Opto
     #         description: A friendly furry creature with a tail, says 'woof'
     #   )
     class Enum < Opto::Type
-      using Opto::Extension::HashStringOrSymbolKey unless RUBY_VERSION < '2.1'
+      using Opto::Extension::HashStringOrSymbolKey
 
       OPTIONS = {
         options: [],

--- a/lib/opto/types/integer.rb
+++ b/lib/opto/types/integer.rb
@@ -2,11 +2,6 @@ require_relative '../type'
 require 'opto/extensions/snake_case'
 require 'opto/extensions/hash_string_or_symbol_key'
 
-if RUBY_VERSION < '2.1'
-  using Opto::Extension::SnakeCase
-  using Opto::Extension::HashStringOrSymbolKey
-end
-
 module Opto
   module Types
     # A number.
@@ -16,7 +11,7 @@ module Opto
     #   :max - maximum allowed value
     #   :nil_is_zero : set to true if you want to turn a null value into 0
     class Integer < Opto::Type
-      using Opto::Extension::HashStringOrSymbolKey unless RUBY_VERSION < '2.1'
+      using Opto::Extension::HashStringOrSymbolKey
 
       OPTIONS = {
         min: 0,

--- a/lib/opto/types/string.rb
+++ b/lib/opto/types/string.rb
@@ -3,11 +3,6 @@ require 'base64'
 require 'opto/extensions/snake_case'
 require 'opto/extensions/hash_string_or_symbol_key'
 
-if RUBY_VERSION < '2.1'
-  using Opto::Extension::SnakeCase
-  using Opto::Extension::HashStringOrSymbolKey
-end
-
 module Opto
   module Types
     # A string
@@ -25,7 +20,7 @@ module Opto
     #   - capitalize: set to true to upcase the first letter
     #   - hexdigest: valid options: md5, sha1, sha256, sha384, sha512 and nil/false. generate an md5/sha1/etc hexdigest from the value.
     class String < Opto::Type
-      using Opto::Extension::HashStringOrSymbolKey unless RUBY_VERSION < '2.1'
+      using Opto::Extension::HashStringOrSymbolKey
 
       TRANSFORMATIONS = [ :upcase, :downcase, :strip, :chomp, :capitalize ]
 

--- a/lib/opto/types/uri.rb
+++ b/lib/opto/types/uri.rb
@@ -3,11 +3,6 @@ require 'uri'
 require 'opto/extensions/snake_case'
 require 'opto/extensions/hash_string_or_symbol_key'
 
-if RUBY_VERSION < '2.1'
-  using Opto::Extension::SnakeCase
-  using Opto::Extension::HashStringOrSymbolKey
-end
-
 module Opto
   module Types
     # An uri/url.
@@ -15,7 +10,7 @@ module Opto
     # Options:
     #   schemes: an array of allowed schemes, such as ['http', 'https', 'file']
     class Uri < Opto::Type
-      using Opto::Extension::HashStringOrSymbolKey unless RUBY_VERSION < '2.1'
+      using Opto::Extension::HashStringOrSymbolKey
 
       OPTIONS = {
         schemes: [ 'http', 'https' ]

--- a/lib/opto/version.rb
+++ b/lib/opto/version.rb
@@ -1,3 +1,3 @@
 module Opto
-  VERSION = "1.7.0"
+  VERSION = "1.8.0"
 end

--- a/opto.gemspec
+++ b/opto.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 2.1.0"
+
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/spec/opto/extensions_spec.rb
+++ b/spec/opto/extensions_spec.rb
@@ -1,11 +1,7 @@
 require_relative '../spec_helper'
-if RUBY_VERSION < '2.1'
-  using Opto::Extension::SnakeCase
-  using Opto::Extension::HashStringOrSymbolKey
-end
 
 class SnakeTest
-  using Opto::Extension::SnakeCase unless RUBY_VERSION < '2.1'
+  using Opto::Extension::SnakeCase
 
   def self.snakeize(string)
     string.snakecase
@@ -13,7 +9,7 @@ class SnakeTest
 end
 
 class FlexyHashTest
-  using Opto::Extension::HashStringOrSymbolKey unless RUBY_VERSION < '2.1'
+  using Opto::Extension::HashStringOrSymbolKey
 
   def initialize(key, value)
     @hash = { key => value }

--- a/spec/opto/types/string_spec.rb
+++ b/spec/opto/types/string_spec.rb
@@ -14,7 +14,12 @@ describe Opto::Types::String do
     end
 
     it 'converts to nil when string is empty' do
-      expect(subject.new(empty_is_nil: true).sanitize_empty_is_nil("  \n")).to be_nil 
+      expect(subject.new(empty_is_nil: true).sanitize_empty_is_nil("  \n")).to be_nil
+    end
+
+    it 'doesnt convert to nil when string is empty and empty_is_nil is false' do
+      expect(subject.new('empty_is_nil' => false).sanitize_empty_is_nil("")).to eq ''
+      expect(subject.new(empty_is_nil: false).sanitize_empty_is_nil("")).to eq ''
     end
 
     it 'converts to upcase' do


### PR DESCRIPTION
(and symbolize type handler options so that defaults.merge(options) does not create duplicates)
