### PR TITLE
Remember which resolvers have been tried and don't retry

### DIFF
--- a/lib/opto/option.rb
+++ b/lib/opto/option.rb
@@ -199,9 +199,7 @@ module Opto
     def resolve
       resolvers.each do |resolver|
         begin
-          resolver.respond_to?(:before) && resolver.before(self)
-          result = resolver.resolve
-          resolver.respond_to?(:after) && resolver.after(self)
+          result = resolver.try_resolve
         rescue StandardError => ex
           raise ex, "Resolver '#{resolver.origin}' for '#{name}' : #{ex.message}"
         end

--- a/lib/opto/option.rb
+++ b/lib/opto/option.rb
@@ -203,7 +203,7 @@ module Opto
         rescue StandardError => ex
           raise ex, "Resolver '#{resolver.origin}' for '#{name}' : #{ex.message}"
         end
-        if result
+        unless result.nil?
           @origin = resolver.origin
           return result
         end

--- a/lib/opto/resolver.rb
+++ b/lib/opto/resolver.rb
@@ -43,6 +43,28 @@ module Opto
     def initialize(hint = nil, option = nil)
       @hint = hint
       @option = option
+      @tried = false
+    end
+
+    def tried?
+      !!@tried
+    end
+
+    def set_tried
+      @tried = true
+    end
+
+    def reset_tried
+      @tried = false
+    end
+
+    def try_resolve
+      return nil if tried?
+      set_tried
+      self.respond_to?(:before) && self.before
+      result = resolve
+      self.respond_to?(:after) && self.after
+      result
     end
 
     # This is a "base" class, you're supposed to inherit from this in your resolver and define a #resolve method.

--- a/lib/opto/resolvers/condition.rb
+++ b/lib/opto/resolvers/condition.rb
@@ -79,6 +79,10 @@ module Opto
         matching_condition = conditions.find {|c| c.true? }
         matching_condition.result
       end
+
+      def after
+        reset_tried # conditional value can change if some of the depending variables change values
+      end
     end
   end
 end

--- a/lib/opto/resolvers/evaluate.rb
+++ b/lib/opto/resolvers/evaluate.rb
@@ -27,6 +27,10 @@ module Opto
           raise TypeError, "Syntax error: '#{interpolated_hint}' does not look like a number or a calculation"
         end
       end
+
+      def after
+        reset_tried
+      end
     end
   end
 end

--- a/lib/opto/resolvers/interpolate.rb
+++ b/lib/opto/resolvers/interpolate.rb
@@ -25,6 +25,10 @@ module Opto
           option.value_of(var)
         end
       end
+
+      def after
+        reset_tried
+      end
     end
   end
 end

--- a/spec/opto/option_spec.rb
+++ b/spec/opto/option_spec.rb
@@ -182,26 +182,17 @@ describe Opto::Option do
       end
 
       it 'returns a resolved value' do
-        expect(resolver).to receive(:resolve).and_return('blerbz')
+        expect(resolver).to receive(:try_resolve).and_return('blerbz')
         instance = klass.new(base_opts.merge(from: { env: 'FOO_OPT'}, value: nil, default: nil))
         expect(instance.value).to eq 'blerbz'
       end
 
       it 'adds the option name in the exception message if a resolver raises' do
         instance = klass.new(base_opts.merge(from: { env: nil }, value: nil, default: nil))
-        expect(resolver).to receive(:resolve).and_raise(ArgumentError, "boo")
+        expect(resolver).to receive(:try_resolve).and_raise(ArgumentError, "boo")
         expect{instance.value}.to raise_error(ArgumentError) do |ex|
           expect(ex.message).to start_with("Resolver 'double' for 'foo' :")
         end
-      end
-
-      it 'calls before & after' do
-        allow(resolver).to receive(:respond_to?).and_return(true)
-        expect(resolver).to receive(:before).and_return(true)
-        expect(resolver).to receive(:after).and_return(true)
-        expect(resolver).to receive(:resolve).and_return('blerbz')
-        instance = klass.new(base_opts.merge(from: { env: 'FOO_OPT'}, value: nil, default: nil))
-        expect(instance.value).to eq 'blerbz'
       end
     end
 

--- a/spec/opto/resolver_spec.rb
+++ b/spec/opto/resolver_spec.rb
@@ -3,6 +3,7 @@ require 'ostruct'
 
 describe Opto::Resolver do
   after(:each) do
+    # have to do it like this instead of Class.new because the class name is significant.
     Object.send(:remove_const, :ResolverTest) if Object.const_defined?(:ResolverTest)
   end
 
@@ -34,6 +35,12 @@ describe Opto::Resolver do
     it 'knows its parent option' do
       expect(Opto::Resolver.for(:resolver_test).new('hint', OpenStruct.new(name: 'foo')).option.name).to eq 'foo'
       expect(Opto::Resolver.for(:resolver_test).new('hint', OpenStruct.new(name: 'foo')).hint).to eq 'hint'
+    end
+
+    it 'only tries once' do
+      expect(subject).to receive(:resolve).once.and_return(nil)
+      subject.try_resolve
+      subject.try_resolve
     end
   end
 end


### PR DESCRIPTION
Re-running resolvers is mostly not desired (Kontena CLI prompting multiple times for the same thing for example).

This PR will mark resolvers as `tried?` and will not try them again when the value is asked.
