### PR TITLE
Run to_s in string sanitization

### DIFF
--- a/lib/opto/types/string.rb
+++ b/lib/opto/types/string.rb
@@ -37,6 +37,10 @@ module Opto
         !value.nil? && !value.strip.empty? && value != 'false'
       end
 
+      sanitizer :to_s do |value|
+        value.nil? ? nil : value.to_s
+      end
+
       sanitizer :encode_64 do |value|
         (options[:encode_64] && value) ? Base64.encode64(value) : value
       end

--- a/spec/opto/types/string_spec.rb
+++ b/spec/opto/types/string_spec.rb
@@ -5,6 +5,15 @@ describe Opto::Types::String do
   let(:subject) { described_class }
 
   context 'sanitize' do
+    it 'converts booleans to strings' do
+      expect(subject.new.sanitize_to_s(false)).to eq "false"
+      expect(subject.new.sanitize_to_s(true)).to eq "true"
+    end
+
+    it 'converts numbers to strings' do
+      expect(subject.new.sanitize_to_s(1)).to eq "1"
+    end
+
     it 'converts a string to base64' do
       expect(Base64.decode64(subject.new(encode_64: true).sanitize_encode_64("foo"))).to eq "foo"
     end


### PR DESCRIPTION
As discussed in https://github.com/kontena/kontena/issues/1875

YAML will turn something like:

```yaml
foo: false
```

into a boolean.

```
type: string
value: false
````

should result in a string with the literal "false". Also numbers should become strings.
