### PR TITLE
Allow overriding setters and resolvers on group level

### DIFF
--- a/lib/opto/group.rb
+++ b/lib/opto/group.rb
@@ -11,33 +11,50 @@ module Opto
 
     using Opto::Extension::HashStringOrSymbolKey
 
-    attr_reader :options, :defaults
-
     extend Forwardable
 
     # Initialize a new Option Group. You can also pass in :defaults.
     #
     # @param [Array<Hash,Opto::Option>,Hash,NilClass] opts An array of Option definition hashes or Option objects or a hash like { var_name: { opts } }.
     # @return [Opto::Group]
-    def initialize(*options)
-      if options.size > 0
-        if options.last.kind_of?(Hash) && options.last[:defaults]
-          @defaults = options.pop[:defaults]
-        end
-        @options =
-          case options.first
-          when NilClass
-            []
-          when Hash
-            options.first.map {|k,v| Option.new({name: k.to_s, group: self}.merge(v))}
-          when ::Array
-            options.first.map {|opt| opt.kind_of?(Opto::Option) ? opt : Option.new(opt.merge(group: self)) }
-          else
-            raise TypeError, "Invalid type #{options.first.class} for Opto::Group.new"
+    def initialize(*opts)
+      case opts.first
+      when NilClass
+      when Hash
+        defaults.merge!(opts.first.delete(:defaults)) if opts.first.key?(:defaults)
+        setters.merge!(opts.first.delete(:setters)) if opts.first.key?(:setters)
+        resolvers.merge!(opts.first.delete(:resolvers)) if opts.first.key?(:resolvers)
+        options.concat(opts.first.map {|k,v| Option.new({name: k.to_s, group: self}.merge(v))})
+      when ::Array
+        if opts.last.is_a?(Hash) && !opts.last.key?(:type)
+          opts.pop.tap do |settings|
+            defaults.merge!(settings[:defaults]) if settings.key?(:defaults)
+            setters.merge!(settings[:setters]) if settings.key?(:setters)
+            resolvers.merge!(settings[:resolvers]) if settings.key?(:resolvers)
           end
+        end
+        if opts.first.kind_of?(Array)
+          options.concat(opts.first.map { |opt| opt.kind_of?(Opto::Option) ? opt : Option.new(opt.merge(group: self)) })
+        end
       else
-        @options = []
+        raise TypeError, "Invalid type #{opts.class} for Opto::Group.new"
       end
+    end
+
+    def options
+      @options ||= []
+    end
+
+    def setters
+      @setters ||= {}
+    end
+
+    def resolvers
+      @resolvers ||= {}
+    end
+
+    def defaults
+      @defaults ||= {}
     end
 
     # Are all options valid? (Option value passes validation)
@@ -180,6 +197,6 @@ module Opto
       end
     end
 
-    def_delegators :@options, *(::Array.instance_methods - [:__send__, :object_id, :to_h, :to_a, :is_a?, :kind_of?, :instance_of?, :self, :inspect, :nil?])
+    def_delegators :options, *(::Array.instance_methods - [:__send__, :object_id, :to_h, :to_a, :is_a?, :kind_of?, :instance_of?, :self, :inspect, :nil?])
   end
 end

--- a/lib/opto/option.rb
+++ b/lib/opto/option.rb
@@ -87,9 +87,14 @@ module Opto
       @from          = normalize_from_to(opts.delete(:from))
       @to            = normalize_from_to(opts.delete(:to))
       @type_options  = opts
+      @tried_resolve = false
 
       set_initial(val) if val
       deep_merge_defaults
+    end
+
+    def has_group?
+      !group.nil?
     end
 
     def deep_merge_defaults
@@ -140,7 +145,7 @@ module Opto
     # Returns true if this field should not be processed because of the conditionals
     # @return [Boolean]
     def skip?
-      return false if group.nil?
+      return false unless has_group?
       return true if group.any_true?(skip_if)
       return true unless group.all_true?(only_if)
       false
@@ -150,7 +155,8 @@ module Opto
     # @param [String] option_name
     def value_of(option_name)
       return value if option_name == self.name
-      group.nil? ? nil : group.value_of(option_name)
+      return nil unless has_group?
+      group.value_of(option_name)
     end
 
     # Run validators
@@ -181,11 +187,11 @@ module Opto
     # Accessor to defined resolvers for this option.
     # @return [Array<Opto::Resolver>]
     def resolvers
-      @resolvers ||= from.merge(default: self).map { |origin, hint| Resolver.for(origin).new(hint, self) }
+      @resolvers ||= from.merge(default: self).map { |origin, hint| { origin: origin, hint: hint, resolver: ((has_group? && group.resolvers[origin]) || Resolver.for(origin)) } }
     end
 
     def setters
-      @setters ||= to.map { |target, hint| Setter.for(target).new(hint, self) }
+      @setters ||= to.map { |target, hint| { target: target, hint: hint, setter: ((has_group? && group.setters[target]) || Setter.for(target)) } }
     end
 
     # True if this field is defined as required: true
@@ -194,32 +200,55 @@ module Opto
       handler.required?
     end
 
+    def tried_resolve?
+      @tried_resolve
+    end
+
+    def set_tried
+      @tried_resolve = true
+    end
+
+    def unset_tried!
+      @tried_resolve = false
+    end
+
     # Run resolvers
     # @raise [TypeError, ArgumentError]
     def resolve
-      resolvers.each do |resolver|
+      return nil if tried_resolve?
+      resolvers.each do |resolver_config|
         begin
-          result = resolver.try_resolve
+          resolver = resolver_config[:resolver]
+          if resolver.respond_to?(:call)
+            result = resolver.call(resolver_config[:hint], self)
+          else
+            result = resolver.new(resolver_config[:hint], self).resolve
+          end
         rescue StandardError => ex
-          raise ex, "Resolver '#{resolver.origin}' for '#{name}' : #{ex.message}"
+          raise ex, "Resolver '#{resolver_config[:origin]}' for '#{name}' : #{ex.message}"
         end
         unless result.nil?
-          @origin = resolver.origin
+          @origin = resolver_config[:origin]
           return result
         end
       end
       nil
+    ensure
+      set_tried
     end
 
     # Run setters
     def output
-      setters.each do |setter|
+      setters.each do |setter_config|
         begin
-          setter.respond_to?(:before) && setter.before(self)
-          setter.set(value)
-          setter.respond_to?(:after)  && setter.after(self)
+          setter = setter_config[:setter]
+          if setter.respond_to?(:call)
+            setter.call(setter_config[:hint], value, self)
+          else
+            setter.new(setter_config[:hint], self).set(value)
+          end
         rescue StandardError => ex
-          raise ex, "Setter '#{setter.target}' for '#{name}' : #{ex.message}"
+          raise ex, "Setter '#{setter_config[:target]}' for '#{name}' : #{ex.message}"
         end
       end
     end

--- a/lib/opto/resolver.rb
+++ b/lib/opto/resolver.rb
@@ -43,28 +43,6 @@ module Opto
     def initialize(hint = nil, option = nil)
       @hint = hint
       @option = option
-      @tried = false
-    end
-
-    def tried?
-      !!@tried
-    end
-
-    def set_tried
-      @tried = true
-    end
-
-    def reset_tried
-      @tried = false
-    end
-
-    def try_resolve
-      return nil if tried?
-      set_tried
-      self.respond_to?(:before) && self.before
-      result = resolve
-      self.respond_to?(:after) && self.after
-      result
     end
 
     # This is a "base" class, you're supposed to inherit from this in your resolver and define a #resolve method.

--- a/spec/opto/group_spec.rb
+++ b/spec/opto/group_spec.rb
@@ -45,7 +45,7 @@ describe Opto::Group do
   end
 
   it '#run runs all the setters for valid non-skipped options' do
-    setter = double(:setter)
+    setter = double
     expect(Opto::Setter).to receive(:for).with(:env).twice.and_return(setter)
     expect(setter).to receive(:new).with('BAZBAZ', instance_of(Opto::Option)).and_return(setter)
     expect(setter).to receive(:new).with('DOGDOG', instance_of(Opto::Option)).and_return(setter)
@@ -98,6 +98,18 @@ describe Opto::Group do
     grp = Opto::Group.new(defaults: { type: :string })
     opt = grp.build_option(name: 'foo')
     expect(opt.type).to eq 'string'
+  end
+
+  it 'supports defining proc resolvers' do
+    group = subject.new(resolvers: { magicians_hat: proc { "rabbit" } }, surprise: { type: :string, from: { 'magicians_hat' => 'foo' } })
+    expect(group.value_of('surprise')).to eq 'rabbit'
+  end
+
+  it 'supports defininig proc setters' do
+    setter = double
+    expect(setter).to receive(:set).with('meow')
+    group = subject.new(setters: { vault: proc { |_, val, _| setter.set(val) } }, cat: { type: :string, value: 'meow', to: 'vault' })
+    expect(group.run)
   end
 end
 

--- a/spec/opto/option_spec.rb
+++ b/spec/opto/option_spec.rb
@@ -120,8 +120,8 @@ describe Opto::Option do
     end
 
     describe '#setters' do
-      it 'returns an array of Setters' do
-        expect(subject.setters.all? {|r| r.kind_of?(Opto::Setter) }).to be_truthy
+      it 'returns an array of setter configs' do
+        expect(subject.setters).to match array_including(hash_including(:target, :hint, :setter))
       end
     end
 
@@ -145,28 +145,18 @@ describe Opto::Option do
         subject.output
       end
 
-      it 'calls before & after' do
-        expect(setter).to receive(:new).and_return(setter)
-        expect(setter).to receive(:set).and_return(true)
-        allow(setter).to receive(:respond_to?).and_return(true)
-        expect(setter).to receive(:before).and_return(true)
-        expect(setter).to receive(:after).and_return(true)
-        subject.set('blerb')
-        subject.output
-      end
-
       it 'adds the option name in the exception message if a setter raises' do
         expect(setter).to receive(:new).and_return(setter)
         expect(setter).to receive(:set).and_raise(ArgumentError, "boo")
         expect{subject.output}.to raise_error(ArgumentError) do |ex|
-          expect(ex.message).to start_with("Setter 'double' for 'foo' :")
+          expect(ex.message).to start_with("Setter 'env' for 'foo' :")
         end
       end
     end
 
     describe '#resolvers' do
       it 'returns an array of Resolvers' do
-        expect(subject.resolvers.all? {|r| r.kind_of?(Opto::Resolver) }).to be_truthy
+        expect(subject.resolvers).to match array_including(hash_including(:origin, :hint, :resolver))
       end
     end
 
@@ -182,16 +172,16 @@ describe Opto::Option do
       end
 
       it 'returns a resolved value' do
-        expect(resolver).to receive(:try_resolve).and_return('blerbz')
+        expect(resolver).to receive(:resolve).and_return('blerbz')
         instance = klass.new(base_opts.merge(from: { env: 'FOO_OPT'}, value: nil, default: nil))
         expect(instance.value).to eq 'blerbz'
       end
 
       it 'adds the option name in the exception message if a resolver raises' do
         instance = klass.new(base_opts.merge(from: { env: nil }, value: nil, default: nil))
-        expect(resolver).to receive(:try_resolve).and_raise(ArgumentError, "boo")
+        expect(resolver).to receive(:resolve).and_raise(ArgumentError, "boo")
         expect{instance.value}.to raise_error(ArgumentError) do |ex|
-          expect(ex.message).to start_with("Resolver 'double' for 'foo' :")
+          expect(ex.message).to start_with("Resolver 'env' for 'foo' :")
         end
       end
     end

--- a/spec/opto/resolver_spec.rb
+++ b/spec/opto/resolver_spec.rb
@@ -2,45 +2,19 @@ require_relative '../spec_helper'
 require 'ostruct'
 
 describe Opto::Resolver do
-  after(:each) do
-    # have to do it like this instead of Class.new because the class name is significant.
-    Object.send(:remove_const, :ResolverTest) if Object.const_defined?(:ResolverTest)
-  end
-
   context 'base' do
-    let(:klass) {
-      class ResolverTest < Opto::Resolver
-      end
-      ResolverTest
-    }
-
-    let(:subject) { klass.new }
+    let(:subject) { described_class.new }
 
     it 'is a base class for resolvers so it raises if the required #resolve method is not defined' do
       expect{subject.resolve}.to raise_error(RuntimeError)
     end
 
     it 'creates an "origin" tag for itself' do
-      expect(subject.origin).to eq :resolver_test
-    end
-
-    it 'can return a suitable resolver by name' do
-      expect(Opto::Resolver.for(:resolver_test).name).to eq klass.name
+      expect(subject.origin).to eq :resolver
     end
 
     it 'raises if a suitable resolver is not found' do
       expect{Opto::Resolver.for(:foo_bar)}.to raise_error(NameError)
-    end
-
-    it 'knows its parent option' do
-      expect(Opto::Resolver.for(:resolver_test).new('hint', OpenStruct.new(name: 'foo')).option.name).to eq 'foo'
-      expect(Opto::Resolver.for(:resolver_test).new('hint', OpenStruct.new(name: 'foo')).hint).to eq 'hint'
-    end
-
-    it 'only tries once' do
-      expect(subject).to receive(:resolve).once.and_return(nil)
-      subject.try_resolve
-      subject.try_resolve
     end
   end
 end

--- a/spec/opto/resolvers/condition_spec.rb
+++ b/spec/opto/resolvers/condition_spec.rb
@@ -32,8 +32,10 @@ describe Opto::Resolvers::Condition do
 
       group.option('str').set('foo')
       expect(opt.resolve).to eq 'foofoo'
+      opt.unset_tried!
       group.option('str').set('bar')
       expect(opt.resolve).to eq 'barbar'
+      opt.unset_tried!
       group.option('str').set('baz')
       expect(opt.resolve).to eq 'foobar'
     end
@@ -54,19 +56,26 @@ describe Opto::Resolvers::Condition do
 
       group.option('str').set('foo')
       expect(opt.resolve).to eq 'foobar'
+      opt.unset_tried!
       group.option('int').set(5)
       expect(opt.resolve).to eq 'foobar'
+      opt.unset_tried!
       group.option('int').set(10)
       expect(opt.resolve).to eq 'foobar'
+      opt.unset_tried!
       group.option('int').set(9)
       expect(opt.resolve).to eq 'foobar'
+      opt.unset_tried!
       group.option('str').set("foovoodoo")
       group.option('int').set(5)
       expect(opt.resolve).to eq 'foobar'
+      opt.unset_tried!
       group.option('int').set(10)
       expect(opt.resolve).to eq 'foobar'
+      opt.unset_tried!
       group.option('int').set(9)
       expect(opt.resolve).to eq 'foofoo'
+      opt.unset_tried!
       group.option('str').set("foodoodoo")
       expect(opt.resolve).to eq 'foobar'
     end


### PR DESCRIPTION
For doing something like:


```ruby
Opto::Group.new(...., resolvers: { etcfile: proc { |hint| File.read("/etc/#{hint}") }})
```

Removes the before/after hook thing that was not used for anything.
