### PR TITLE
YAML resolver and Group type

### DIFF
--- a/lib/opto/group.rb
+++ b/lib/opto/group.rb
@@ -108,7 +108,25 @@ module Opto
     # @param [String] option_name
     # @return [Opto::Option]
     def option(option_name)
-      options.find { |opt| opt.name == option_name }
+      if option_name.to_s.include?('.')
+        parts = option_name.to_s.split('.')
+        var_name = parts.pop
+        group = parts.inject(self) do |base, part|
+          grp = base.option(part).value
+          if grp.nil?
+            raise NameError, "No such group: #{base.name}.#{part}"
+          elsif grp.kind_of?(Opto::Group)
+            grp
+          else
+            raise TypeError, "Is not a group: #{base.name}.#{part}"
+          end
+        end
+      else
+        group = self
+        var_name = option_name
+      end
+
+      group.options.find { |opt| opt.name == var_name }
     end
 
     # Get a value of a member by option name

--- a/lib/opto/resolvers/condition.rb
+++ b/lib/opto/resolvers/condition.rb
@@ -79,10 +79,6 @@ module Opto
         matching_condition = conditions.find {|c| c.true? }
         matching_condition.result
       end
-
-      def after
-        reset_tried # conditional value can change if some of the depending variables change values
-      end
     end
   end
 end

--- a/lib/opto/resolvers/evaluate.rb
+++ b/lib/opto/resolvers/evaluate.rb
@@ -10,7 +10,7 @@ module Opto
 
       def resolve
         raise TypeError, "String required" unless hint.kind_of?(String)
-        interpolated_hint = hint.gsub(/(?<!\$)\$(?!\$)\{?\w+\}?/) do |v|
+        interpolated_hint = hint.gsub(/(?<!\$)\$(?!\$)\{?[\w\.]+\}?/) do |v|
           var = v.tr('${}', '')
           if option.group.nil? || option.group.option(var).nil?
             raise RuntimeError, "Variable #{var} not declared"
@@ -26,10 +26,6 @@ module Opto
         else
           raise TypeError, "Syntax error: '#{interpolated_hint}' does not look like a number or a calculation"
         end
-      end
-
-      def after
-        reset_tried
       end
     end
   end

--- a/lib/opto/resolvers/interpolate.rb
+++ b/lib/opto/resolvers/interpolate.rb
@@ -14,20 +14,16 @@ module Opto
 
       def resolve
         raise TypeError, "String expected" unless hint.kind_of?(String)
-        hint.gsub(/(?<!\$)\$(?!\$)\{?\w+\}?/) do |v|
+        hint.gsub(/(?<!\$)\$(?!\$)\{?[\w\.]+\}?/) do |v|
           var = v.tr('${}', '')
-          if option.group.nil? || option.group.option(var).nil?
-            raise RuntimeError, "Variable #{var} not declared"
-          end
-          if option.value_of(var).nil?
-            raise RuntimeError, "No value for #{var}, note that the order is meaningful"
-          end
-          option.value_of(var)
-        end
-      end
 
-      def after
-        reset_tried
+          raise RuntimeError, "Variable #{var} not declared" if option.group.nil?
+          opt = option.group.option(var)
+          raise RuntimeError, "Variable #{var} not declared" if opt.nil?
+          value = opt.value
+          raise RuntimeError, "No value for #{var}, note that the order is meaningful" if value.nil?
+          value
+        end
       end
     end
   end

--- a/lib/opto/resolvers/yaml.rb
+++ b/lib/opto/resolvers/yaml.rb
@@ -1,0 +1,36 @@
+require 'opto/extensions/snake_case'
+require 'opto/extensions/hash_string_or_symbol_key'
+
+module Opto
+  module Resolvers
+    # Loads values from YAML files
+    #
+    # Example:
+    # from:
+    #   yaml:
+    #     file: foofoo.yml
+    #     key: foo
+    class Yaml < Opto::Resolver
+
+      using Opto::Extension::HashStringOrSymbolKey
+
+      def resolve
+        raise TypeError, "Hash expected" unless hint.kind_of?(Hash)
+        raise TypeError, "Missing file definition" unless hint[:file]
+
+        require 'yaml' unless Kernel.const_defined?(:YAML)
+        yaml = YAML.safe_load(::File.read(hint[:file]), [], [], true, hint[:file])
+        if hint[:key]
+          raise TypeError, "Data file #{hint[:file]} is not a hash" unless yaml.kind_of?(Hash)
+          if yaml.key?(hint[:key])
+            yaml[hint[:key]]
+          elsif hint[:key].include?('.')
+            yaml.dig(*hint[:key].split('.'))
+          end
+        else
+          yaml
+        end
+      end
+    end
+  end
+end

--- a/lib/opto/types/group.rb
+++ b/lib/opto/types/group.rb
@@ -1,0 +1,28 @@
+require_relative '../type'
+
+module Opto
+  module Types
+    # A subgroup
+    class Group < Opto::Type
+      using Opto::Extension::HashStringOrSymbolKey
+
+      true_when do |value|
+        value.kind_of?(Opto::Group) && !value.empty?
+      end
+
+      sanitizer :init do |value|
+        if options[:variables]
+          Opto::Group.new(options[:variables])
+        elsif value.kind_of?(::Hash) || value.kind_of?(::Array)
+          Opto::Group.new(value)
+        elsif value.kind_of?(Opto::Group)
+          value
+        elsif value.nil?
+          Opto::Group.new
+        else
+          raise TypeError, "Invalid type #{value.class.name} for a group"
+        end
+      end
+    end
+  end
+end

--- a/spec/opto/resolvers/interpolate_spec.rb
+++ b/spec/opto/resolvers/interpolate_spec.rb
@@ -16,6 +16,28 @@ describe Opto::Resolvers::Interpolate do
       opt_3 = group.build_option(type: :string, name: 'greeting', from: { interpolate: '$hi ${place}'})
       expect(opt_3.value).to eq 'hello world'
     end
+
+    it 'interpolates values from sub-options into a string' do
+      group = Opto::Group.new(
+        'foo' => {
+          type: :group,
+          value: {
+            'bar' => {
+              type: :string,
+              value: 'hello'
+            }
+          }
+        },
+        'baz' => {
+          type: :string,
+          from: {
+            interpolate: "${foo.bar}, world"
+          }
+        }
+      )
+
+      expect(group.option('baz').value).to eq "hello, world"
+    end
   end
 end
 

--- a/spec/opto/resolvers/yaml_spec.rb
+++ b/spec/opto/resolvers/yaml_spec.rb
@@ -1,0 +1,44 @@
+require_relative '../../spec_helper'
+
+describe Opto::Resolvers::Yaml do
+
+  describe '#resolve' do
+    let(:subject) { described_class }
+
+    it 'raises if hint is not a hash' do
+      expect{subject.new(nil).resolve}.to raise_error(TypeError)
+    end
+
+    it 'raises if hint hash does not contain file' do
+      expect{subject.new(key: 'foo').resolve}.to raise_error(TypeError)
+    end
+
+    it 'reads values from a yaml file into a string' do
+      expect(File).to receive(:read).with('foofoo.yml').and_return(YAML.dump('abc' => '123'))
+      allow(File).to receive(:read).and_call_original
+      opt = Opto::Option.new(type: :string, from: { yaml: { file: 'foofoo.yml', key: 'abc' } } )
+      expect(opt.value).to eq '123'
+    end
+
+    it 'reads values from a nested yaml file into a string' do
+      expect(File).to receive(:read).with('foofoo.yml').and_return(YAML.dump('abc' => { 'def' => '123' }))
+      allow(File).to receive(:read).and_call_original
+      opt = Opto::Option.new(type: :string, from: { yaml: { file: 'foofoo.yml', key: 'abc.def' } } )
+      expect(opt.value).to eq '123'
+    end
+
+    it 'reads values from a yaml file into a string without a key' do
+      expect(File).to receive(:read).with('foofoo.yml').and_return("hello")
+      allow(File).to receive(:read).and_call_original
+      opt = Opto::Option.new(type: :string, from: { yaml: { file: 'foofoo.yml' } } )
+      expect(opt.value).to eq 'hello'
+    end
+
+    it 'reads values from a yaml file into an array' do
+      expect(File).to receive(:read).with('foofoo.yml').and_return(YAML.dump('abc' => ['123', '456']))
+      allow(File).to receive(:read).and_call_original
+      opt = Opto::Option.new(type: :array, from: { yaml: { file: 'foofoo.yml', key: 'abc' } } )
+      expect(opt.value).to eq ['123', '456']
+    end
+  end
+end

--- a/spec/opto/resolvers/yaml_spec.rb
+++ b/spec/opto/resolvers/yaml_spec.rb
@@ -40,5 +40,15 @@ describe Opto::Resolvers::Yaml do
       opt = Opto::Option.new(type: :array, from: { yaml: { file: 'foofoo.yml', key: 'abc' } } )
       expect(opt.value).to eq ['123', '456']
     end
+
+    it 'can read a yaml as a group' do
+      expect(File).to receive(:read).with('foofoo.yml').and_return(YAML.dump('abc' => { 'type' => 'string', 'value' => 'world' }))
+      allow(File).to receive(:read).and_call_original
+      group = Opto::Group.new(
+        foo: { type: :group, from: { yaml: { file: 'foofoo.yml' }}},
+        bar: { type: :string, from: { interpolate: "hello, ${foo.abc}" } }
+      )
+      expect(group.value_of('bar')).to eq "hello, world"
+    end
   end
 end

--- a/spec/opto/types/group_spec.rb
+++ b/spec/opto/types/group_spec.rb
@@ -1,0 +1,20 @@
+require_relative '../../spec_helper'
+
+describe Opto::Types::Group do
+  let(:subject) { described_class }
+
+  it 'should have an empty group initially' do
+    group = Opto::Option.new(type: :group, name: 'foogroup')
+    expect(group.value).to be_kind_of(Opto::Group)
+  end
+
+  it 'should allow access to sub variables' do
+    group = Opto::Option.new(type: :group, name: 'foogroup', value: { 'abc' => { type: :string, value: '123' } })
+    expect(group.value_of('foogroup').value_of('abc')).to eq '123'
+  end
+
+  it 'should accept value in variables-option' do
+    group = Opto::Option.new(type: :group, name: 'foogroup', variables: { 'abc' => { type: :string, value: '123' } })
+    expect(group.value_of('foogroup').value_of('abc')).to eq '123'
+  end
+end


### PR DESCRIPTION
You can now use `yaml` as a resolver:

```yaml
variables:
  foo:
    type: :string
    from:
      yaml:
        file: other_yaml.yml
        key: abc.def
---
# other_yaml.yml
abc:
  def: 123
```

You can now nest groups:

```yaml
variables:
  foo:
    type: group
    value:
      bar:
        type: string
        value: world
  greeting:
    type: string
    from:
      interpolate: "hello, ${foo.bar}" # <-- becomes hello, world
```

