### PR TITLE
Enable parsing YAML from a string variable

### DIFF
--- a/spec/opto/resolvers/yaml_spec.rb
+++ b/spec/opto/resolvers/yaml_spec.rb
@@ -50,5 +50,13 @@ describe Opto::Resolvers::Yaml do
       )
       expect(group.value_of('bar')).to eq "hello, world"
     end
+
+    it 'can read yaml from a variable' do
+      group = Opto::Group.new(
+        origin: { type: :string, value: YAML.dump('foo' => 'bar') },
+        dest: { type: :string, from: { yaml: { variable: 'origin', key: 'foo' } } }
+      )
+      expect(group.value_of('dest')).to eq 'bar'
+    end
   end
 end


### PR DESCRIPTION
A quick addition to #42 

Allows reading YAML content from a string variable:

```yaml
yaml_content:
  type: string
  value: |
    foo: bar
var:
  type: string
  from:
    yaml:
      variable: yaml_content
      key: foo
```
