### PR TITLE
Fix group.to_h with subgroups

### DIFF
--- a/lib/opto/group.rb
+++ b/lib/opto/group.rb
@@ -77,15 +77,15 @@ module Opto
 
     # Convert Group to an Array of Hashes (by calling .to_h on each member)
     # @return [Array<Hash>]
-    def to_a(with_errors: false, with_value: false)
-      options.map {|opt| opt.to_h(with_errors: with_errors, with_value: with_value) }
+    def to_a(with_errors: false, with_values: false)
+      options.map {|opt| opt.to_h(with_errors: with_errors, with_value: with_values) }
     end
 
     # Convert a Group to a hash that has { option_name => option_value }
     # @return [Hash]
     def to_h(values_only: false, with_values: false, with_errors: false)
       if values_only
-        Hash[*options.flat_map {|opt| [opt.name, opt.value]}]
+        Hash[*options.flat_map {|opt| [opt.name, opt.type == 'group' ? opt.value.to_h(values_only: true) : opt.value]}]
       else
         Hash[*options.flat_map {|opt| [opt.name, opt.to_h(with_value: with_values, with_errors: with_errors).reject {|k,_| k==:name}]}]
       end

--- a/lib/opto/option.rb
+++ b/lib/opto/option.rb
@@ -138,7 +138,13 @@ module Opto
       hash[:skip_if] = skip_if if skip_if
       hash[:only_if] = only_if if only_if
       hash[:errors]  = errors  if with_errors
-      hash[:value]   = value   if with_value
+      if with_value
+        if type == 'group'
+          hash[:value]   = value.to_h(with_values: true, with_errors: with_errors)
+        else
+          hash[:value] = value
+        end
+      end
       hash
     end
 

--- a/spec/opto/types/group_spec.rb
+++ b/spec/opto/types/group_spec.rb
@@ -17,4 +17,30 @@ describe Opto::Types::Group do
     group = Opto::Option.new(type: :group, name: 'foogroup', variables: { 'abc' => { type: :string, value: '123' } })
     expect(group.value_of('foogroup').value_of('abc')).to eq '123'
   end
+
+  describe 'to_h' do
+    it 'should hashify the subgroup values as nested hash using values_only: true' do
+      group = Opto::Group.new({'foo' => { type: :group, value: { 'abc' => { type: :string, value: '123' }}}})
+      expect(group.to_h(values_only: true)).to match hash_including(
+        'foo' => hash_including(
+          'abc' => '123'
+        )
+      )
+    end
+
+    it 'should hashify the subgroup values as nested variables definition' do
+      group = Opto::Group.new({'foo' => { type: :group, value: { 'abc' => { type: :string, value: '123' }}}})
+      expect(group.to_h(with_values: true)).to match hash_including(
+        'foo' => hash_including(
+          type: 'group',
+          value: hash_including(
+            'abc' => hash_including(
+              type: 'string',
+              value: '123'
+            )
+          )
+        )
+      )
+    end
+  end
 end


### PR DESCRIPTION
`group.to_h` or `option.to_h` with nested subgroups returned a hash with `#<Opto::Option::Group ..>` as value instead of a nested hash.
